### PR TITLE
binary op sparse fix

### DIFF
--- a/maskedtensor/binary.py
+++ b/maskedtensor/binary.py
@@ -131,11 +131,13 @@ def torch_binary(fn_name):
                 raise ValueError(
                     "Sparse indices must match. If you need support for this, please open an issue on Github."
                 )
+            assert data_args[0].size() == data_args[1].size()
             i = data_args[0].indices()
+            size = data_args[0].size()
             data_args[0] = data_args[0].values()
             data_args[1] = data_args[1].values()
             v = fn(*data_args)
-            result_data = torch.sparse_coo_tensor(i, v)
+            result_data = torch.sparse_coo_tensor(i, v, size)
         else:
             result_data = fn(*data_args)
             # sparse tensors don't have strides
@@ -169,11 +171,13 @@ def torch_inplace_binary(fn_name):
                 raise ValueError(
                     "Sparse indices must match. If you need support for this, please open an issue on Github."
                 )
+            assert data_args[0].size() == data_args[1].size()
             i = data_args[0].indices()
+            size = data_args[0].size()
             data_args[0] = data_args[0].values()
             data_args[1] = data_args[1].values()
             v = fn(*data_args)
-            result_data = torch.sparse_coo_tensor(i, v)
+            result_data = torch.sparse_coo_tensor(i, v, size)
         else:
             result_data = fn(*data_args)
 

--- a/maskedtensor/reductions.py
+++ b/maskedtensor/reductions.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
 import torch
+
 from maskedtensor import MaskedTensor
 
 

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
 import torch
+from torch.testing._internal.common_utils import make_tensor
 
 
 def _compare_mt_t(mt_result, t_result):
@@ -47,3 +48,9 @@ def masks_match(a, b):
         mask_b = b.masked_mask
         return tensors_match(mask_a, mask_b)
     return True
+
+
+def _create_random_mask(shape, device):
+    return make_tensor(
+        shape, device=device, dtype=torch.bool, low=0, high=1, requires_grad=False
+    )

--- a/test/maskedtensor_additional_op_db.py
+++ b/test/maskedtensor_additional_op_db.py
@@ -5,6 +5,7 @@ from functools import partial
 import numpy as np
 import scipy
 import torch
+from common_utils import _create_random_mask
 from torch.testing import (
     all_types,
     all_types_and,
@@ -49,12 +50,6 @@ M = 10
 S = 5
 
 
-def create_mask(shape, device):
-    return make_tensor(
-        shape, device=device, dtype=torch.bool, low=0, high=1, requires_grad=False
-    )
-
-
 def sample_inputs_clamp_scalar(op_info, device, dtype, requires_grad, **kwargs):
     shapes = [(2, 3, 2), (2, 0, 3)]
 
@@ -74,7 +69,7 @@ def sample_inputs_clamp_scalar(op_info, device, dtype, requires_grad, **kwargs):
             requires_grad=requires_grad,
         )
         min_val, max_val = vals
-        mask = create_mask(shape, device)
+        mask = _create_random_mask(shape, device)
         output.append(
             SampleInput(
                 tensor.clone().requires_grad_(requires_grad),

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,5 +1,5 @@
 import torch
-from common_utils import _compare_mt_t
+from common_utils import _compare_mt_t, _create_random_mask
 from maskedtensor import masked_tensor
 from maskedtensor.binary import BINARY_NAMES
 from maskedtensor.unary import UNARY_NAMES
@@ -27,26 +27,26 @@ mt_unary_ufuncs = [op for op in unary_ufuncs if is_unary(op)]
 mt_binary_ufuncs = [op for op in binary_ufuncs if is_binary(op)]
 
 MASKEDTENSOR_FLOAT_TYPES = {
-    torch.float16,
     torch.float32,
     torch.float64,
 }
 
 
-def _test_native_masked_result_equality(device, dtype, op, is_sparse=False):
+def _test_unary_binary_equality(device, dtype, op, is_sparse=False):
     samples = op.sample_inputs(device, dtype, requires_grad=True)
 
     for sample in samples:
         input = sample.input
         sample_args, sample_kwargs = sample.args, sample.kwargs
-        if "mask" not in sample_kwargs:
-            mask = create_mask(input.shape, device)
-        else:
-            mask = sample_kwargs.pop("mask")
+        mask = (
+            _create_random_mask(input.shape, device)
+            if "mask" not in sample_kwargs
+            else sample_kwargs.pop("mask")
+        )
 
         if is_sparse:
-            input = input.to_sparse_coo()
-            mask = mask.to_sparse_coo()
+            mask = mask.to_sparse_coo().coalesce()
+            input = input.sparse_mask(mask)
 
         # Binary operations currently only support same size masks
         if is_binary(op):
@@ -58,7 +58,7 @@ def _test_native_masked_result_equality(device, dtype, op, is_sparse=False):
 
         mt = masked_tensor(input, mask)
         mt_args = [
-            masked_tensor(arg.to_sparse_coo() if is_sparse else arg, mask)
+            masked_tensor(arg.sparse_mask(mask) if is_sparse else arg, mask)
             if torch.is_tensor(arg)
             else arg
             for arg in sample_args
@@ -86,15 +86,15 @@ class TestOperators(TestCase):
         }
         if op.name == "round" and op.variant_test_name in skip_variants:
             return
-        _test_native_masked_result_equality(device, dtype, op)
+        _test_unary_binary_equality(device, dtype, op)
 
     @ops(mt_binary_ufuncs, allowed_dtypes=MASKEDTENSOR_FLOAT_TYPES)
     def test_binary_core(self, device, dtype, op):
-        _test_native_masked_result_equality(device, dtype, op)
+        _test_unary_binary_equality(device, dtype, op)
 
     @ops(additional_op_db, allowed_dtypes=(torch.float,))
     def test_maskedtensor_result(self, device, dtype, op):
-        _test_native_masked_result_equality(device, dtype, op)
+        _test_unary_binary_equality(device, dtype, op)
 
     @ops(mt_unary_ufuncs, allowed_dtypes=MASKEDTENSOR_FLOAT_TYPES)
     def test_unary_core_sparse(self, device, dtype, op):
@@ -106,15 +106,15 @@ class TestOperators(TestCase):
         }
         if op.name == "round" and op.variant_test_name in skip_variants:
             return
-        _test_native_masked_result_equality(device, dtype, op, True)
+        _test_unary_binary_equality(device, dtype, op, True)
 
     @ops(mt_binary_ufuncs, allowed_dtypes=MASKEDTENSOR_FLOAT_TYPES)
     def test_binary_core_sparse(self, device, dtype, op):
-        _test_native_masked_result_equality(device, dtype, op, True)
+        _test_unary_binary_equality(device, dtype, op, True)
 
     @ops(additional_op_db, allowed_dtypes=(torch.float,))
     def test_maskedtensor_results_sparse(self, device, dtype, op):
-        _test_native_masked_result_equality(device, dtype, op, True)
+        _test_unary_binary_equality(device, dtype, op, True)
 
 
 only_for = ("cpu", "cuda")

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -3,7 +3,7 @@ from common_utils import _compare_mt_t, _create_random_mask
 from maskedtensor import masked_tensor
 from maskedtensor.binary import BINARY_NAMES
 from maskedtensor.unary import UNARY_NAMES
-from maskedtensor_additional_op_db import additional_op_db, create_mask
+from maskedtensor_additional_op_db import additional_op_db
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     ops,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #59

Differential Revision: [D36109702](https://our.internmc.facebook.com/intern/diff/D36109702)

Fixing an issue where the entire last row of mask could be False, therefore resulting in a sparse tensor that doesn't inherit the original size and becomes smaller than intended